### PR TITLE
Added ordinal indicator for All, Portugues, Italian and Spanish

### DIFF
--- a/PowerAccent.Core/Languages.cs
+++ b/PowerAccent.Core/Languages.cs
@@ -97,7 +97,7 @@ internal static class Languages
             case LetterKey._9:
                 return new char[] { '₉', '⁹' };
             case LetterKey.A:
-                return new char[] { 'á', 'à', 'ä', 'â', 'ă', 'å', 'α', 'ā', 'ą', 'ȧ', 'ã', 'æ' };
+                return new char[] { 'á', 'à', 'ä', 'â', 'ă', 'å', 'α', 'ā', 'ą', 'ȧ', 'ã', 'æ', 'ª' };
             case LetterKey.B:
                 return new char[] { 'ḃ', 'β' };
             case LetterKey.C:
@@ -125,7 +125,7 @@ internal static class Languages
             case LetterKey.N:
                 return new char[] { 'ñ', 'ń', 'ŋ', 'ň', 'ņ', 'ṅ', 'ⁿ', 'ν' };
             case LetterKey.O:
-                return new char[] { 'ô', 'ó', 'ö', 'ő', 'ò', 'ō', 'ȯ', 'ø', 'õ', 'œ', 'ω' };
+                return new char[] { 'ô', 'ó', 'ö', 'ő', 'ò', 'ō', 'ȯ', 'ø', 'õ', 'œ', 'ω', 'º' };
             case LetterKey.P:
                 return new char[] { 'ṗ', '₽', 'π', 'φ', 'ψ' };
             case LetterKey.R:

--- a/PowerAccent.Core/Languages.cs
+++ b/PowerAccent.Core/Languages.cs
@@ -277,7 +277,7 @@ internal static class Languages
         switch (letter)
         {
             case LetterKey.A:
-                return new char[] { 'á' };
+                return new char[] { 'á', 'ª' };
             case LetterKey.E:
                 return new char[] { 'é', '€' };
             case LetterKey.I:
@@ -285,7 +285,7 @@ internal static class Languages
             case LetterKey.N:
                 return new char[] { 'ñ' };
             case LetterKey.O:
-                return new char[] { 'ó' };
+                return new char[] { 'ó', 'º' };
             case LetterKey.U:
                 return new char[] { 'ú', 'ü' };
             case LetterKey._:
@@ -437,7 +437,7 @@ internal static class Languages
         switch (letter)
         {
             case LetterKey.A:
-                return new char[] { 'á', 'à', 'â', 'ã' };
+                return new char[] { 'á', 'à', 'â', 'ã', 'ª' };
             case LetterKey.C:
                 return new char[] { 'ç' };
             case LetterKey.E:
@@ -445,7 +445,7 @@ internal static class Languages
             case LetterKey.I:
                 return new char[] { 'í' };
             case LetterKey.O:
-                return new char[] { 'ó', 'ô', 'õ' };
+                return new char[] { 'ó', 'ô', 'õ', 'º' };
             case LetterKey.P:
                 return new char[] { 'π' };
             case LetterKey.U:
@@ -593,13 +593,13 @@ internal static class Languages
         switch (letter)
         {
             case LetterKey.A:
-                return new char[] { 'à' };
+                return new char[] { 'à', 'ª' };
             case LetterKey.E:
                 return new char[] { 'è', 'é', '€' };
             case LetterKey.I:
                 return new char[] { 'ì', 'í' };
             case LetterKey.O:
-                return new char[] { 'ò', 'ó' };
+                return new char[] { 'ò', 'ó', 'º' };
             case LetterKey.U:
                 return new char[] { 'ù', 'ú' };
         }


### PR DESCRIPTION
I just added ordinal indicator for All, Portugues, Italian and Spanish.

This indicator is vary used in Portuguese to express number like this in English 2ⁿᵈ and in Portuguese would be , 2º.

Please accept it.